### PR TITLE
added support for logfile-per-domain environments

### DIFF
--- a/src/apachetop.cc
+++ b/src/apachetop.cc
@@ -4,6 +4,8 @@
 */
 #include "apachetop.h"
 
+#include "inlines.cc"
+
 /* die and report why */
 #define DIE(msg) fprintf(stderr, "%s: %s\n", msg, strerror(errno)); catchsig(1);
 /* die with no strerror */
@@ -276,6 +278,10 @@ int main(int argc, char *argv[])
 	hm->create(cf.circle_size);
 	/* }}} */
 
+	/* file string -> file hash map */
+	fm = new map;
+	fm->create(cf.circle_size);
+
 	memset(&gstats, 0, sizeof(gstats));
 	gstats.start = time(NULL);
 
@@ -491,6 +497,10 @@ int main(int argc, char *argv[])
 					/* record which file the log is from */
 					lb.fileid = fd;
 
+					char* filename = basename(curfile->filename);
+					lb.file_pos  = fm->insert(filename);
+					lb.file_hash = TTHash(filename);
+
 					/* insert into circle */
 					c->insert(lb);
 
@@ -664,9 +674,18 @@ int read_key(int ch) /* {{{ */
 				case DISPLAY_HOSTS:
 					cf.display_mode = DISPLAY_REFS;
 					break;
+#if HAVE_FILE_MODE_DISPLAY
+				case DISPLAY_REFS:
+					cf.display_mode = DISPLAY_FILES;
+					break;
+				case DISPLAY_FILES:
+					cf.display_mode = DISPLAY_URLS;
+					break;
+#else
 				case DISPLAY_REFS:
 					cf.display_mode = DISPLAY_URLS;
 					break;
+#endif
 			}
 			cf.do_immed_display = true;
 			break;

--- a/src/apachetop.h
+++ b/src/apachetop.h
@@ -1,6 +1,8 @@
 #ifndef _APACHETOP_H_
 #define _APACHETOP_H_
 
+#define HAVE_FILE_MODE_DISPLAY 1
+
 #if HAVE_CONFIG_H
 # include "config.h"
 #endif
@@ -268,7 +270,7 @@ struct gstat {
 #define COLS_RESERVED 25
 #define LINES_RESERVED 7
 
-#define MAX_INPUT_FILES 50
+#define MAX_INPUT_FILES 2000
 
 int recordstats(struct logbits l);
 

--- a/src/display.cc
+++ b/src/display.cc
@@ -157,6 +157,36 @@ bool display(time_t last_display) /* {{{ */
 				cur_offset += size + 1;
 			}
 			break;
+
+		case DISPLAY_FILES:
+			/* show URLs and IPs */
+			num_sections =
+			    (cf.detail_display_urls ? 1 : 0) +
+			    (cf.detail_display_hosts ? 1 : 0) +
+			    (cf.detail_display_refs ? 1 : 0);
+
+			/* anything to do? */
+			if (num_sections == 0) break;
+
+			size = (((LINES-LINES_RESERVED-2) - FIRST_OFFSET) /
+			    num_sections);
+
+			if (cf.detail_display_urls)
+			{
+				display_sub_list(DISPLAY_URLS,cur_offset,size);
+				cur_offset += size + 1;
+			}
+			if (cf.detail_display_hosts)
+			{
+				display_sub_list(DISPLAY_HOSTS,cur_offset,size);
+				cur_offset += size + 1;
+			}
+			if (cf.detail_display_refs)
+			{
+				display_sub_list(DISPLAY_REFS,cur_offset,size);
+				cur_offset += size + 1;
+			}
+			break;
 	}
 	refresh();
 
@@ -555,6 +585,10 @@ void display_list() /* {{{ */
 		case DISPLAY_REFS:
 		mvaddstr(LINES_RESERVED-1, 23, "REFERRER");
 		break;
+
+		case DISPLAY_FILES:
+		mvaddstr(LINES_RESERVED-1, 23, "FILE");
+		break;
 	}
 
 	disp = 0; /* count how many we've shown */
@@ -655,6 +689,7 @@ void display_sub_list(short display_mode_override, /* {{{ */
 		case DISPLAY_URLS: map = um; break;
 		case DISPLAY_HOSTS: map = hm; break;
 		case DISPLAY_REFS: map = rm; break;
+		case DISPLAY_FILES: map = fm; break;
 	}
 
 	/* walk the entire circle */
@@ -677,6 +712,7 @@ void display_sub_list(short display_mode_override, /* {{{ */
 			case DISPLAY_URLS: h = lb->url_hash; break;
 			case DISPLAY_HOSTS: h = lb->host_hash; break;
 			case DISPLAY_REFS: h = lb->ref_hash; break;
+			case DISPLAY_FILES: h = lb->file_hash; break;
 		}
 
 		/* we're only interested in this circle item if it matches
@@ -691,6 +727,7 @@ void display_sub_list(short display_mode_override, /* {{{ */
 			case DISPLAY_URLS: pos = lb->url_pos; break;
 			case DISPLAY_HOSTS: pos = lb->host_pos; break;
 			case DISPLAY_REFS: pos = lb->ref_pos; break;
+			case DISPLAY_FILES: pos = lb->file_pos; break;
 		}
 
 		/* look up whatever string this pos is for */
@@ -782,6 +819,10 @@ void display_sub_list(short display_mode_override, /* {{{ */
 
 		case DISPLAY_REFS:
 			mvaddstr(LINES_RESERVED+offset-1, 23, "REFERRER");
+			break;
+
+		case DISPLAY_FILES:
+			mvaddstr(LINES_RESERVED+offset-1, 23, "FILE");
 			break;
 	}
 

--- a/src/log.h
+++ b/src/log.h
@@ -36,6 +36,7 @@ struct logbits {
 
 	int fileid;               /* which file descriptor we're from */
 	int file_pos;             /* location of file in filemap */
+	int file_hash;            /* hash of file string */
 
 	unsigned short retcode;   /* return code */
 	unsigned int bytes;       /* body of result page */


### PR DESCRIPTION
Hosting environments often tend to use an individual log file for each domain.
As the domain name isn't included in the URL, the name of the log file is the only clue on which domain a request was served for.
In conjunction with the following command, a large number of log files can be handled by apachetop and the names of the log files can be shown to the user.

`ls -t /var/log/apache2/logs/*.log | head -n 2000 | sed -e 's/^/-f /' | xargs -o apachetop`